### PR TITLE
fix: Firelights Markdown Syntax Typo

### DIFF
--- a/public/catalog/creators/fari-rpgs/firelights/index.md
+++ b/public/catalog/creators/fari-rpgs/firelights/index.md
@@ -166,7 +166,7 @@ When you confront a Curse, **Action+Approach**. Repeat until you’ve stacked en
 
 When you avoid an impending threat, **Action+Approach**.
 
-- Upon** Light**, you avoid the **danger**.
+- Upon **Light**, you avoid the **danger**.
 - Upon **Shade**, mark **1 Fatigue**.
 - Upon **Darkness**, mark **2 Fatigue**.
 


### PR DESCRIPTION
This fixes the bolding markdown for the Firelights SRD.